### PR TITLE
Added use_auth_header option for switching between Authorization and Signature headers

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -102,6 +102,16 @@ class TestRequestsHTTPSignature(unittest.TestCase):
         auth = HTTPSignatureAuth(algorithm="rsa-sha256", key=private_key_pem, key_id="sekret", passphrase=passphrase)
         self.session.get(url, auth=auth, headers=dict(pubkey=base64.b64encode(public_key_pem)))
 
+    def test_can_use_signature_header(self):
+        auth = auth=HTTPSignatureAuth(
+            key=hmac_secret, key_id="sekret", use_auth_header=False)
+        r = requests.Request(
+            url='http://test.com', auth=auth)
+        prepared = r.prepare()
+
+        self.assertIn('Signature', prepared.headers)
+        self.assertTrue(prepared.headers['Signature'].startswith('keyId='))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi and thank you for maintaining this software!

We've been using a fork in production for more than a year now on https://funkwhale.audio/, a decentralized audio streaming software that relies heavily on HTTP signatures to authenticate requests.

The protocol we use relies on the `Signature:` header instead of the `Authorization:` header though, so we had to tweak this package a bit, as included in this PR, to support using the `Signature` header instead.

Maybe you'd like this to be included upstream?

Let me know if you need anything :)