### PR TITLE
Allow missing created field

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/requests_http_signature/__init__.py
+++ b/requests_http_signature/__init__.py
@@ -123,8 +123,10 @@ class HTTPSignatureAuth(requests.auth.AuthBase):
             ("algorithm", self.algorithm),
             ("headers", " ".join(self.headers)),
             ("signature", sig),
-            ("created", int(created_timestamp)),
         ]
+        if not (self.algorithm.startswith("rsa") or self.algorithm.startswith("hmac") or
+                self.algorithm.startswith("ecdsa")):
+            sig_struct.append(("created", int(created_timestamp)))
         if expires_timestamp is not None:
             sig_struct.append(("expires", int(expires_timestamp)))
         return ",".join('{}="{}"'.format(k, v) for k, v in sig_struct)

--- a/requests_http_signature/__init__.py
+++ b/requests_http_signature/__init__.py
@@ -87,7 +87,7 @@ class HTTPSignatureAuth(requests.auth.AuthBase):
             if header == "(request-target)":
                 path_url = requests.models.RequestEncodingMixin.path_url.fget(request)
                 sts.append("{}: {} {}".format(header, request.method.lower(), path_url))
-            elif header == "(created)":
+            elif header == "(created)" and created_timestamp:
                 sts.append("{}: {}".format(header, created_timestamp))
             elif header == "(expires)":
                 assert (expires_timestamp is not None), \
@@ -157,7 +157,7 @@ class HTTPSignatureAuth(requests.auth.AuthBase):
         for field in "keyId", "algorithm", "signature":
             assert field in sig_struct, 'Required signature parameter "{}" not found'.format(field)
         assert sig_struct["algorithm"] in self.known_algorithms, "Unknown signature algorithm"
-        created_timestamp = int(sig_struct['created'])
+        created_timestamp = int(sig_struct['created']) if 'created' in sig_struct else None
         expires_timestamp = sig_struct.get('expires')
         if expires_timestamp is not None:
             expires_timestamp = int(expires_timestamp)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal=1
 [flake8]
 max-line-length=120
-ignore: E301, E302, E401, E261, E265, E226, F401
+ignore: E301, E302, E401, E261, E265, E226, F401, W504


### PR DESCRIPTION
The problem to solve is described in #22 
solves #22 

The first problem is the addition of the `created` field when creating the signature with algorithms `rsa`, `hmac` or `ecdsa`. This is solved by the first commit.
