### PR TITLE
Remove deprecated setuptools entrypoint of flake8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test_deps:
 	pip install coverage flake8 wheel
 
 lint: test_deps
-	./setup.py flake8
+	flake8 $$(python setup.py --name | sed 's/-/_/g')
 
 test: test_deps lint
 	coverage run --source=$$(python setup.py --name | sed 's/-/_/g') ./test/test.py


### PR DESCRIPTION
flake8 deprecated the entrypoint via setup.py. This is described here: https://github.com/PyCQA/flake8/issues/1098

I suggest these changes to make sure this will still work with flake8 4.0