### PR TITLE
minor PEP 8 fixes, expired signature check

### DIFF
--- a/requests_http_signature/__init__.py
+++ b/requests_http_signature/__init__.py
@@ -166,6 +166,9 @@ class HTTPSignatureAuth(requests.auth.AuthBase):
         sts = self.get_string_to_sign(request, headers, created_timestamp, expires_timestamp=expires_timestamp)
         key = key_resolver(key_id=sig_struct["keyId"], algorithm=sig_struct["algorithm"])
         Crypto(sig_struct["algorithm"]).verify(sig, sts, key)
+        if expires_timestamp is not None:
+            assert expires_timestamp > created_timestamp
+
 
 class HTTPSignatureHeaderAuth(HTTPSignatureAuth):
     """

--- a/requests_http_signature/__init__.py
+++ b/requests_http_signature/__init__.py
@@ -167,7 +167,7 @@ class HTTPSignatureAuth(requests.auth.AuthBase):
         key = key_resolver(key_id=sig_struct["keyId"], algorithm=sig_struct["algorithm"])
         Crypto(sig_struct["algorithm"]).verify(sig, sts, key)
         if expires_timestamp is not None:
-            assert expires_timestamp > created_timestamp
+            assert expires_timestamp > int(time.time())
 
 
 class HTTPSignatureHeaderAuth(HTTPSignatureAuth):

--- a/test/test.py
+++ b/test/test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os, sys, unittest, logging, base64
 from datetime import timedelta
@@ -44,8 +44,6 @@ class DigestlessSignatureAuth(HTTPSignatureAuth):
 
 class TestRequestsHTTPSignature(unittest.TestCase):
     def setUp(self):
-        if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
-            setattr(unittest.TestCase, 'assertRaisesRegex', unittest.TestCase.assertRaisesRegexp)
         logging.basicConfig(level="DEBUG")
         self.session = requests.Session()
         self.session.mount("http://", TestAdapter(self))

--- a/test/test.py
+++ b/test/test.py
@@ -6,6 +6,7 @@ import os, sys, unittest, logging, base64
 from datetime import timedelta
 
 import requests
+from cryptography.fernet import Fernet
 from requests.adapters import HTTPAdapter
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))) # noqa
@@ -67,14 +68,14 @@ class TestRequestsHTTPSignature(unittest.TestCase):
     def test_expired_signature(self):
         with self.assertRaises(AssertionError):
             preshared_key_id = 'squirrel'
-            preshared_secret = 'monorail_cat'
+            key = Fernet.generate_key()
             one_month = timedelta(days=-30)
             headers = ["(expires)"]
-            auth = HTTPSignatureAuth(key=preshared_secret, key_id=preshared_key_id,
+            auth = HTTPSignatureAuth(key=key, key_id=preshared_key_id,
                                      expires_in=one_month, headers=headers)
 
             def key_resolver(key_id, algorithm):
-                return preshared_secret
+                return key
 
             url = 'http://example.com/path'
             response = requests.get(url, auth=auth)

--- a/test/test.py
+++ b/test/test.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 
-import os, sys, unittest, json, logging, base64
+import os, sys, unittest, logging, base64
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -13,8 +13,10 @@ from requests_http_signature import HTTPSignatureAuth, HTTPSignatureHeaderAuth, 
 hmac_secret = b"monorail_cat"
 passphrase = b"passw0rd"
 
+
 class TestAdapter(HTTPAdapter):
     def __init__(self, testcase):
+        super(TestAdapter, self).__init__()
         self.testcase = testcase
 
     def send(self, request, *args, **kwargs):
@@ -33,12 +35,16 @@ class TestAdapter(HTTPAdapter):
         response.url = request.url
         return response
 
+
 class DigestlessSignatureAuth(HTTPSignatureAuth):
     def add_digest(self, request):
         pass
 
+
 class TestRequestsHTTPSignature(unittest.TestCase):
     def setUp(self):
+        if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
+            setattr(unittest.TestCase, 'assertRaisesRegex', unittest.TestCase.assertRaisesRegexp)
         logging.basicConfig(level="DEBUG")
         self.session = requests.Session()
         self.session.mount("http://", TestAdapter(self))


### PR DESCRIPTION
test_basic_statements test does not run in python 2.7 because `unittest.TestCase.assertRaisesRegexp` has been renamed to `unittest.TestCase.assertRaisesRegex` (without the last 'p') since python 3.2.

2nd commit uses `expires_timestamp` to check expiration time.

3rd one adds a test.