### PR TITLE
Alternate digest algorithms

### DIFF
--- a/requests_http_signature/__init__.py
+++ b/requests_http_signature/__init__.py
@@ -82,9 +82,10 @@ class HTTPSignatureAuth(requests.auth.AuthBase):
         return request.body
 
     def add_digest(self, request):
-        if request.body is None and "digest" in self.headers:
+        content = self.digest_content
+        if content is None and "digest" in self.headers:
             raise RequestsHttpSignatureException("Could not compute digest header for request without a body")
-        if request.body is not None and "Digest" not in request.headers:
+        if content is not None and "Digest" not in request.headers:
             if "digest" not in self.headers:
                 self.headers.append("digest")
             hash = hashlib.new(self.digest_alg)


### PR DESCRIPTION
Needed SHA-512 digests.  Implemented SHA-1, SHA-256, and SHA-512 instead of hardcoding SHA-256 (The spec offers CRC32C and ADLER and a couple others, but they're in zlib and would require a bit more code -- not sure there'd be many users for the extra work).  Also, the current spec calls for the tokens ('sha-256') to be lowercase with a dash.  Hashlib, unfortunately, returns 'sha256' for .name, so used a dict (known_digests) to apply the correct tokens for the spec. 

In addition, I separated out a method to return the request body instead of using it directly for the digest.  The spec does not specify that ONLY the body may be used for the digest (In my case, I need one of the headers included as well), so this allows a developer to override the content that is, er, digested. 